### PR TITLE
Trailing Slash

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -19,7 +19,7 @@ RewriteRule ^imgs/.*$ - [PT]
 RewriteRule ^home skillsheet.php [L,NC,NS]
 RewriteRule ^add skillsheet.php?show=addnew [L,NC,NS]
 RewriteRule ^stats skillsheet.php?show=stats [L,NC,NS]
-RewriteRule ^([^-]+)/$ skillsheet.php?name=$1 [L,NC,NS]
+RewriteRule ^(?!skillsheet)([^-/]+)/?$ skillsheet.php?name=$1 [L,NC,NS]
 RewriteRule ^pilot/([^-]+)$ skillsheet.php?name=$1 [L,NC,NS]
 RewriteRule ^([^-]+)/([^-]+)?$ skillsheet.php?name=$1&show=$2 [L,NC,NS]
 


### PR DESCRIPTION
Hi, 

Having now bothered to install the Webapp and have a play (rather than just guessing)
I've fixed the trailing slash issue (It's the way Apache's mod_rewrite was capturing everything
as the Regex was a little to liberal)  

I've tested this on my local version and it works.

Original Commit message: 

The issue was the way that Apache mod_rewrite was working.
Adding a negative lookahead I made it not pass "skillsheet.php" as
the character name request param, thus not confusing the EVE class.
